### PR TITLE
Fix androidx crash and change profile image to a circular image view

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.google.android.material:material:1.0.0'
+    implementation 'de.hdodenhof:circleimageview:3.0.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
 
+
     <application
             android:allowBackup="true"
             android:icon="@mipmap/ic_launcher"
@@ -11,16 +12,19 @@
             android:roundIcon="@mipmap/ic_launcher_round"
             android:supportsRtl="true"
             android:theme="@style/AppTheme">
+        <uses-library android:name="org.apache.http.legacy"
+                      android:required="false" />
         <activity android:name=".Activities.BaseActivity">
         </activity>
         <activity android:name=".Activities.ProfileActivity">
-        </activity>
-        <activity android:name=".Activities.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+        </activity>
+        <activity android:name=".Activities.MainActivity">
+
         </activity>
     </application>
 

--- a/app/src/main/res/layout/activity_base.xml
+++ b/app/src/main/res/layout/activity_base.xml
@@ -34,7 +34,7 @@
 
     <com.google.android.material.navigation.NavigationView
             android:fitsSystemWindows="true"
-            app:menu="@menu/nav_drawer_menu"
+            app:menu="@menu/navigation"
             android:id="@+id/nav_view"
             android:layout_gravity="start"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
         xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -24,4 +24,4 @@
             app:layout_constraintStart_toStartOf="parent" android:layout_marginStart="126dp"
             android:layout_marginEnd="126dp" app:layout_constraintEnd_toEndOf="parent"/>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
         android:padding="15dp"
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
@@ -9,16 +9,20 @@
         tools:context=".Activities.ProfileActivity">
 
 
-    <ImageView android:id="@+id/image_profile_picture"
-               android:layout_width="wrap_content"
-               android:layout_height="300dp"
-               app:layout_constraintTop_toTopOf="parent"
-               app:layout_constraintStart_toStartOf="parent"
-               app:layout_constraintEnd_toEndOf="parent"
-               android:src="@drawable/ic_launcher_background"
-               android:adjustViewBounds="true"/>
+    <de.hdodenhof.circleimageview.CircleImageView
+            android:layout_width="200dp"
+            android:layout_height="200dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_marginTop="24dp"
+            android:layout_centerHorizontal="true"
+            android:src="@drawable/ic_launcher_background"
+            android:id="@+id/image_profile_picture"
+    />
 
     <TextView android:id="@+id/text_profile_name"
+              android:layout_marginTop="50dp"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
               app:layout_constraintTop_toBottomOf="@id/image_profile_picture"
@@ -159,4 +163,4 @@
             android:layout_width="match_parent" android:layout_height="wrap_content"
     app:layout_constraintBottom_toBottomOf="parent"
     android:text="Go to my listings"/>
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
# Description

Fixed androidx library crash with constraint layout, implemented circularImageView library, and changed profile image to Circular Image View

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code

